### PR TITLE
Team-Entwicklung

### DIFF
--- a/frontend/js/del_stats.js
+++ b/frontend/js/del_stats.js
@@ -71,6 +71,36 @@ app.factory('svc', function() {
                 total += list[i][attribute];
             }
             return total;
+        },
+        getFilteredAccumulatedTotal: function(list, attribute, dataSource, to) {
+            if (dataSource === undefined) {
+                return
+            }
+            var total = 0;
+            for(var i = list.length-1; i >= 0; i--){
+                total += list[i][attribute];
+                if (list[i]['round'] == to)
+                {
+                    return total;
+                }
+            }
+            return total;
+        },
+        getFilteredAverageTotal: function(list, attribute, dataSource, to) {
+            if (dataSource === undefined) {
+                return
+            }
+            var total = 0;
+            var cnt_data = 0;
+            for(var i = list.length-1; i >= 0; i--){
+                cnt_data++;
+                total += list[i][attribute];
+                if (list[i]['round'] == to)
+                {
+                    return total/cnt_data;
+                }
+            }
+            return total/cnt_data;
         }
     }
 });

--- a/frontend/js/team_profile_columns.json
+++ b/frontend/js/team_profile_columns.json
@@ -72,6 +72,19 @@
         {"data_key": "opp_pp_goals", "col_header": "PPGA", "expl_de": "Gegentore in Unterzahl", "expl_en": "Powerplay Goals Against"},
         {"data_key": "pk_pctg", "col_header": "PK%", "expl_de": "Unterzahlquote", "expl_en": "Penalty Killing Percentage"},
         {"data_key": "sh_goals", "col_header": "SHGF", "expl_de": "Unterzahltore", "expl_en": "Shorthanded Goals For"}
+    ],
+    "development": [
+        {"data_key": "date", "col_header": "Datum", "expl_de": null, "expl_en": null},
+        {"data_key": "round", "col_header": "Spieltag", "expl_de": null, "expl_en": null},
+        {"data_key": "opp_team", "col_header": "Gegner", "expl_de": null, "expl_en": null},
+        {"data_key": "points", "col_header": "PTS", "expl_de": null, "expl_en": null},
+        {"data_key": "shot_pctg", "col_header": "SH%", "expl_de": "Schussquote", "expl_en": "Shooting Percentage"},
+        {"data_key": "pp_pctg", "col_header": "PP%", "expl_de": "Powerplayquote", "expl_en": "Powerplay Percentage"},
+        {"data_key": "pk_pctg", "col_header": "PK%", "expl_de": "Unterzahlquote", "expl_en": "Penalty Killing Percentage"},
+        {"data_key": "faceoff_pctg", "col_header": "FAC%", "expl_de": "Anteil der gewonnenen Bullies", "expl_en": "Faceoff Percentage"},
+        {"data_key": "pdo", "col_header": "PDO", "expl_de": "PDO-Wert (Schuss- und Fangquote kombiniert)", "expl_en": "PDO"},
+        {"data_key": "goals_sum", "col_header": "GF", "expl_de": "Tore (ohne Penaltyschießen) gesamt bis zu diesem Spieltag", "expl_en": "Goals For (without Shootout) total until this gameday"},
+        {"data_key": "opp_goals_sum", "col_header": "GA", "expl_de": "Gegentore (ohne Penaltyschießen) gesamt bis zu diesem Spieltag", "expl_en": "Goals Against (without Shootout) total until this gameday"}
     ]
 
 }

--- a/frontend/team_profile.html
+++ b/frontend/team_profile.html
@@ -45,6 +45,7 @@
                     <option data-ng-option value="special_team_stats">Über-/Unterzahlstatistiken</option>
                     <option data-ng-option value="game_additional_stats">Zusätzliche Statistiken</option>
                     <option data-ng-option value="game_refs">Schieds-/Linienrichter</option>
+                    <option data-ng-option value="development">Team-Entwicklung</option>
                 </select>
                 <span class="input-group-addon form_spacer"></span>
                 <select class="form-control" id="home_away_select" data-ng-model="homeAwayFilter">
@@ -347,6 +348,37 @@
                 <td class="col-md-1 text-right">{{ total_opp_pp_goals = svc.getFilteredTotal(filtered_game_log, 'opp_pp_goals', 'game_log') }}</td>
                 <td class="col-md-1 text-right">{{ (100 - total_opp_pp_goals / total_opp_pp_opps * 100).toFixed(1) }} %</td>
                 <td class="col-md-1 text-right">{{ svc.getFilteredTotal(filtered_game_log, 'sh_goals', 'game_log') }}</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <table id="development" class="table table-bordered table-striped table-condensed" data-ng-if="tableSelect == 'development'">
+        <thead>
+            <tr>
+                <td class="text-center" data-ng-repeat="col in stats_cols[tableSelect]">
+                    <abbr title={{col.expl_de}} data-ng-if="col.expl_de">{{col.col_header}}</abbr>
+                    <span data-ng-if="!col.expl_de">{{col.col_header}}</span>
+                </td>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="{{game.home_away === 'home'? 'info' : 'warning'}}" data-ng-repeat="game in filtered_game_log = (game_log | orderBy:sortCriterion:statsSortDescending | filter: {home_away: homeAwayFilter} | filter:dayFilter | filter: {opp_team: oppFilter})">
+                <td class="col-md-1 text-center"><a href="http://anonymto.com/?https://www.del.org/spielplan/{{game.game_date}}#schedule">{{
+                        game.game_date }}</a></td>
+                <td class="col-md-1 text-right" style="width: 6%">{{ game.round }}</td>
+                <td class="col-md-1{{ setTextColor(game.score, game.opp_score) }}" style="width: 10%"><b>{{ game.score
+                        }}:{{game.opp_score}} </b><a href="http://anonymto.com/?https://www.del.org/event/{{game.home_away === 'home'? team_lookup[game.team] : team_lookup[game.opp_team]}}-{{game.home_away === 'home'? team_lookup[game.opp_team] : team_lookup[game.team]}}/{{game.schedule_game_id}}">{{game.home_away
+                        === 'home'? 'vs.' : '@'}} {{ game.opp_team }} {{game.game_type === 'SO' ? '(SO)' :
+                        game.game_type
+                        === 'OT' ? '(VL)' : ''}}</a></td>
+                <td class="col-md-1 text-right">{{ points_sum           = svc.getFilteredAccumulatedTotal(filtered_game_log, 'points', game_log, game.round) }}</td>
+                <td class="col-md-1 text-right">{{ shot_pctg            = (svc.getFilteredAverageTotal(filtered_game_log, 'shot_pctg', game_log, game.round)).toFixed(2) }}</td>
+                <td class="col-md-1 text-right">{{ pp_pctg              = (svc.getFilteredAverageTotal(filtered_game_log, 'pp_pctg', game_log, game.round)).toFixed(2) }}</td>
+                <td class="col-md-1 text-right">{{ pk_pctg              = (svc.getFilteredAverageTotal(filtered_game_log, 'pk_pctg', game_log, game.round)).toFixed(2) }}</td>
+                <td class="col-md-1 text-right">{{ faceoff_pctg         = (svc.getFilteredAverageTotal(filtered_game_log, 'faceoff_pctg', game_log, game.round)).toFixed(2) }}</td>
+                <td class="col-md-1 text-right">{{ pdo                  = (svc.getFilteredAverageTotal(filtered_game_log, 'pdo', game_log, game.round)).toFixed(2) }}</td>
+                <td class="col-md-1 text-right">{{ goals_total_sum      = svc.getFilteredAccumulatedTotal(filtered_game_log, 'goals', game_log, game.round) }}</td>
+                <td class="col-md-1 text-right">{{ opp_goals_total_sum  = svc.getFilteredAccumulatedTotal(filtered_game_log, 'opp_goals', game_log, game.round) }}</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Da ich gerne sehen wollte, wie sich die Teams im Laufe der Saison entwickeln habe ich selber eine weitere Ansicht im Team Profil hinzugefügt. Dabei geht es mir darum den Durchschnittswert einzelner Statistiken im Laufe der Zeit dazustellen, also wie sich z.B. die PowerPlay Quote im Laufe der Zeit verändert. Somit wären diese Werte natürlich ein Kandidat für eine grafische Darstellung. 

Ich würde mich freuen, wenn du über meinen Vorschlag mal drüberschauen würdest und ggf. sogar pullen würdest. Hättest du überhaupt Interesse an einen weiteren "contributer"?

Lass es mich wissen!

Viele Grüße,
Maarten